### PR TITLE
Update InstallRolesAndFeatures.ps1

### DIFF
--- a/Setup/InstallRolesAndFeatures.ps1
+++ b/Setup/InstallRolesAndFeatures.ps1
@@ -18,8 +18,6 @@ function Main {
         'IIS-HttpErrors',
         'IIS-StaticContent',
         'IIS-RequestFiltering',
-        'IIS-CertProvider',
-        'IIS-IPSecurity',
         'IIS-URLAuthorization',
         'IIS-ApplicationInit',
         'IIS-WindowsAuthentication',
@@ -29,7 +27,6 @@ function Main {
         'IIS-ISAPIFilter',
         'IIS-WebSockets',
         'IIS-ManagementConsole',
-        'IIS-ManagementScriptingTools',
         'ClientForNFS-Infrastructure'
     )
 


### PR DESCRIPTION
Removed unnecessary features, according to customers complaints . 'IIS-CertProvider', 'IIS-IPSecurity', 'IIS-ManagementScriptingTools'.
The doc does not contain these already, so the doc is ahead of the script.